### PR TITLE
Visualize distances with color; improve resize behavior

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,14 +7,16 @@
         <% } %>
     </head>
     <body>
-        <div id="maze-background">
-            <div id="maze"></div>
-        </div>
-        <div id="templates" hidden>
-            <div class="cell">
-                <div class="walls"></div>
-                <div class="vertex"></div>
-                <div class="label"></div>
+        <div id="page-background">
+            <div id="maze-background">
+                <div id="maze"></div>
+            </div>
+            <div id="templates" hidden>
+                <div class="cell">
+                    <div class="walls"></div>
+                    <div class="vertex"></div>
+                    <div class="label"></div>
+                </div>
             </div>
         </div>
     </body>

--- a/src/js/Maze.js
+++ b/src/js/Maze.js
@@ -51,6 +51,42 @@ class Maze {
             return index ===cells.length ? false : true;
         }
     }
+
+    /**
+     * Calculate distance of all maze cells from cell at given index,
+     * then use color to visualize distance.
+     *
+     * @param {number} cellIdx - Index of selected start cell.
+     */
+    colorByDistanceFromCell(cellIdx) {
+        const cells = this.getCells();
+        cells.forEach((cell) => cell.distance = null);
+
+        const startCell = cells[cellIdx];
+        startCell.distance = 0;
+
+        let maxDist = 0;
+        let frontierCells = [startCell];
+
+        while (frontierCells.length) {
+            const newFrontier = [];
+            frontierCells.forEach((cell) => {
+                const accessibleNeighbors = cell.getAccessibleNeighbors();
+                const unvisitedAccessible = accessibleNeighbors.filter((neighbor) => neighbor.distance === null);
+                unvisitedAccessible.forEach((unvisited) => {
+                    unvisited.distance = cell.distance + 1;
+                    maxDist = Math.max(maxDist, unvisited.distance);
+                    newFrontier.push(unvisited);
+                });
+            });
+            frontierCells = newFrontier;
+        }
+
+        // Set hue by normalized distance (i.e. fraction of max dist).
+        cells.forEach((cell) => {
+            cell.color = `hsl(${300 * cell.distance / maxDist}, 100%, 40%)`;
+        });
+    }
 }
 
 export default Maze;

--- a/src/js/Maze.js
+++ b/src/js/Maze.js
@@ -53,39 +53,81 @@ class Maze {
     }
 
     /**
-     * Calculate distance of all maze cells from cell at given index,
-     * then use color to visualize distance.
+     * Generic implementation of breadth-first search. Returns nothing, but exposes
+     * customizable functionality via callback function.
      *
-     * @param {number} cellIdx - Index of selected start cell.
+     * @param {Cell} startCell - Cell to begin searching outwards from.
+     * @param {Function} callback - Takes parent Cell, followed by its child Cell.
      */
-    colorByDistanceFromCell(cellIdx) {
-        const cells = this.getCells();
-        cells.forEach((cell) => cell.distance = null);
+    breadthFirstSearch(startCell, callback) {
+        const distanceDict = {};
+        const visitedCells = new Set([startCell]);
 
-        const startCell = cells[cellIdx];
-        startCell.distance = 0;
-
-        let maxDist = 0;
         let frontierCells = [startCell];
 
         while (frontierCells.length) {
             const newFrontier = [];
             frontierCells.forEach((cell) => {
                 const accessibleNeighbors = cell.getAccessibleNeighbors();
-                const unvisitedAccessible = accessibleNeighbors.filter((neighbor) => neighbor.distance === null);
+                const unvisitedAccessible = accessibleNeighbors.filter((neighbor) => !visitedCells.has(neighbor));
+
                 unvisitedAccessible.forEach((unvisited) => {
-                    unvisited.distance = cell.distance + 1;
-                    maxDist = Math.max(maxDist, unvisited.distance);
+                    callback(cell, unvisited)
                     newFrontier.push(unvisited);
+                    visitedCells.add(unvisited);
                 });
             });
             frontierCells = newFrontier;
         }
+    }
 
-        // Set hue by normalized distance (i.e. fraction of max dist).
-        cells.forEach((cell) => {
-            cell.color = `hsl(${300 * cell.distance / maxDist}, 100%, 40%)`;
+     /**
+     * Calculate distance of all maze cells from cell at given index,
+     * then use color to visualize distance.
+     *
+     * @param {number} startIdx - Index of selected start cell.
+     * @returns {Object.<Cell, number>} Dictionary of distances from start cell.
+     */
+    getDistanceDict(startIdx){
+        const startCell = this.getCells()[startIdx];
+        const distanceDict = {}
+        distanceDict[startCell] = 0;
+
+        this.breadthFirstSearch(startCell, (parent, child)=>{
+            distanceDict[child] = distanceDict[parent] + 1;
         });
+
+        return distanceDict;
+    }
+
+    /**
+     * Uses breadth-first search to find the shortest path between two cells.
+     *
+     * @param {number} startIdx - Index of start cell.
+     * @param {number} endIdx - Index of end cell.
+     * @returns {Array} List of cells in shortest path (including start and end cell).
+     */
+    getShortestPathData(startIdx, endIdx){
+        const cells = this.getCells();
+        const startCell = cells[startIdx];
+        const endCell = cells[endIdx];
+
+        const previousDict = {}
+        previousDict[startCell] = null;
+
+        this.breadthFirstSearch(startCell, (parent, child) => {
+            previousDict[child] = parent;
+        });
+
+        const path = [];
+
+        let prevCell = endCell;
+        while (prevCell !== null) {
+            path.push(prevCell)
+            prevCell = previousDict[prevCell];
+        }
+
+        return path;
     }
 }
 

--- a/src/js/MazeEntity.js
+++ b/src/js/MazeEntity.js
@@ -3,18 +3,25 @@ class MazeEntity {
         Object.assign(this, {maze, row, col});
     }
 
-    getDictOfNeighborsAtDist(distance){
-      const data = this.maze.data, row = this.row, col = this.col;
-      return {
-        'left': col > (distance-1)? data[row][col-distance] : null,
-        'right': col < data[0].length - distance ? data[row][col+distance] : null,
-        'top':  row > (distance-1) ? data[row-distance][col] : null,
-        'bottom': row < data.length - distance ? data[row+distance][col] : null
-      }
+    /**
+     * Override toString to ensure unique key for object in hashtable.
+     */
+    toString() {
+        return `${this.constructor.name}_${this.row}_${this.col}`;
     }
 
-    getListOfNeighborsAtDist(distance){
-      return Object.values(this.getDictOfNeighborsAtDist(distance)).filter((x) => x !== null)
+    getDictOfNeighborsAtDist(distance) {
+        const data = this.maze.data, row = this.row, col = this.col;
+        return {
+            'left': col > (distance - 1) ? data[row][col - distance] : null,
+            'right': col < data[0].length - distance ? data[row][col + distance] : null,
+            'top': row > (distance - 1) ? data[row - distance][col] : null,
+            'bottom': row < data.length - distance ? data[row + distance][col] : null
+        }
+    }
+
+    getListOfNeighborsAtDist(distance) {
+        return Object.values(this.getDictOfNeighborsAtDist(distance)).filter((x) => x !== null)
     }
 }
 

--- a/src/less/style.less
+++ b/src/less/style.less
@@ -3,6 +3,13 @@
 @wallWidth: 13%;
 
 body {
+    margin: 0;
+    padding: 0;
+}
+
+#page-background {
+    width: 100%;
+    height: 100vh;
     background-color: @bgColor;
 }
 
@@ -12,9 +19,16 @@ body {
     top: 50%;
     transform: translate(-50%, -50%);
 
-    background-image: linear-gradient(45deg, cyan, violet);
-    border-radius: 12px;
+    background-image: linear-gradient(45deg, #2ac4ff, #e97ff1);
     overflow: hidden;
+
+    mix-blend-mode: screen;
+
+    &.highlight-foreground {
+        background-image: none;
+        background-color: white;
+        mix-blend-mode: normal;
+    }
 }
 
 #maze {


### PR DESCRIPTION
In standard mode (i.e. not screensaver), click any cell to create a colorful, high-contrast visualization of its distance from all other cells. Click background to reset.

Distances are calculated using a quick-and-dirty breadth-first search, implemented on the `Maze` class.